### PR TITLE
FTT-3725 - Reviewing Lint Rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,9 @@ module.exports = {
     '@typescript-eslint/unbound-method': ['error', { 'ignoreStatic': true }], // Allow referencing unbound methods as long as they are static
     "class-methods-use-this": "off", // Stops us from having to delcare class methods which don't use this as static.
     "@typescript-eslint/interface-name-prefix": "off", // Interfaces don't have to start with a I
-    "lines-between-class-members": "off", // Allows you to not have a blank line between class members
-    "import/no-unresolved": "off", // Allows you to use imports which can't be resolved. For example @azure/functions
-    "@typescript-eslint/no-explicit-any": "off", // Allows you to use the any type
+    "import/no-unresolved": [ // Allows you to use imports which can't be resolved, enabled for everything not in the ignore list.
+      2,
+      { "ignore": ["@azure/functions"] } 
+    ]
   },
 }

--- a/index.js
+++ b/index.js
@@ -26,5 +26,10 @@ module.exports = {
     '@typescript-eslint/no-use-before-define': 'off', // Allow defining functions (incl. arrow expressions) after use as per 'Stepdown Rule' best practice
     'no-param-reassign': ['error', { 'props': false }], // Allow reassigning parameter properties but not whole parameters
     '@typescript-eslint/unbound-method': ['error', { 'ignoreStatic': true }], // Allow referencing unbound methods as long as they are static
+    "class-methods-use-this": "off", // Stops us from having to delcare class methods which don't use this as static.
+    "@typescript-eslint/interface-name-prefix": "off", // Interfaces don't have to start with a I
+    "lines-between-class-members": "off", // Allows you to not have a blank line between class members
+    "import/no-unresolved": "off", // Allows you to use imports which can't be resolved. For example @azure/functions
+    "@typescript-eslint/no-explicit-any": "off", // Allows you to use the any type
   },
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/eslint-config-ts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Shareable ESLint config for Node/Typescript projects",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
As part of reviewing when we bypass lint in FTTS, I would like to open a discussion about changing the following rules:

- class-methods-use-this
- @typescript-eslint/interface-name-prefix
- lines-between-class-members
- import/no-unresolved 
- @typescript-eslint/no-explicit-any


**class-methods-use-this**

Currently manually disabled in the local eslint configs for Locations, Payments, Notifications and the Booking App. Moving it here would simplify the local configurations

**@typescript-eslint/interface-name-prefix**

Currently manually disabled in the local eslint configs for Locations, Payments, Notifications and the Booking App. Moving it here would simplify the local configurations

**lines-between-class-members**

Manually turned off in Locations, Notifications and the Booking App eslint config. Happy to leave this open for discussion if it should/shouldn't be turned off. However it should be consistent across all components 

**import/no-unresolved** 

This is the most common rule we bypass in Locations, Notifications and the Booking App. Payments have disabled this rule in the eslint config.

The only reason we bypass this rule is that it is triggered every time we import something from the @azure/functions package. The amount of instances is increasing as we now import Context  from that package for use in the logger. 

**@typescript-eslint/no-explicit-any**

This rule is already disabled for all test files (manually in each project)  and most instances occur around http responses and responses from other external interfaces. I don't see any harm in turning this rule off as it's something that can be caught easily in code reviews