### PR TITLE
Add Jest plugin to eslint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,22 @@ A few of the default rules are switched off/customised as specified in the confi
 When making changes to this package you are unable to npm link to test the package locally due a bug in npm where peer dependencies are not installed. Github Issue - https://github.com/npm/cli/issues/2339
 
 ### Prerequisites
-- >= npm 7.x.x
-- The following dependencies are not present in your package.json (this package will install them)
--- eslint
--- @typescript-eslint/eslint-plugin
--- @typescript-eslint/typescript-estree
--- eslint-config-airbnb-typescript
--- eslint-plugin-import
--- eslint-plugin-jsx-a11y
--- eslint-plugin-react
--- eslint-plugin-react-hooks
--- eslint-plugin-security
+- \>= npm 7.x.x
+
+If the following dependencies are not present in your package.json, this package will install them (see `peerDependencies` in `package.json`):
+
+```
+eslint
+@typescript-eslint/eslint-plugin
+@typescript-eslint/typescript-estree
+eslint-config-airbnb-typescript
+eslint-plugin-import
+eslint-plugin-jsx-a11y
+eslint-plugin-react
+eslint-plugin-react-hooks
+eslint-plugin-security
+eslint-plugin-jest
+```
 
 ### Usage
 

--- a/index.js
+++ b/index.js
@@ -73,5 +73,7 @@ module.exports = {
       'error',
       { 'props': false }
     ],
+    // @see https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/require-top-level-describe.md
+    "jest/require-top-level-describe": "error",
   },
 }

--- a/index.js
+++ b/index.js
@@ -74,6 +74,9 @@ module.exports = {
       { 'props': false }
     ],
     // @see https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/require-top-level-describe.md
-    "jest/require-top-level-describe": "error",
+    'jest/require-top-level-describe': 'error',
+    // @see https://github.com/jest-community/eslint-plugin-jest/blob/v25.3.0/docs/rules/no-hooks.md
+    // Enable use of hooks (beforeEach/afterEach) - state is useful in most testsuites
+    'jest/no-hooks': 'off',
   },
 }

--- a/index.js
+++ b/index.js
@@ -73,6 +73,5 @@ module.exports = {
       'error',
       { 'props': false }
     ],
-    '@typescript-eslint/unbound-method': 'error',
   },
 }

--- a/index.js
+++ b/index.js
@@ -27,7 +27,8 @@ module.exports = {
     // Security rules
     'plugin:security/recommended',
     // Jest rules
-    'plugin:jest/all'
+    'plugin:jest/recommended',
+    'plugin:jest/style'
   ],
   overrides: [
     // @see https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = {
     // Security rules
     'plugin:security/recommended',
     // Jest rules
-    'plugin:jest/recommended'
+    'plugin:jest/all'
   ],
   overrides: [
     // @see https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = {
-  parser: '@typescript-eslint/parser', // Typescript parser for ESLint
+  // Typescript parser for ESLint
+  parser: '@typescript-eslint/parser',
   parserOptions: {
     ecmaVersion: 2019,
     project: './tsconfig.json',
@@ -11,35 +12,67 @@ module.exports = {
   plugins: [
     '@typescript-eslint',
     'import',
-    'security'
+    'security',
+    'jest'
   ],
   extends: [
-    'airbnb-typescript/base', // Airbnb style guide rules
-    'plugin:@typescript-eslint/recommended', // ESLint Typescript plugin recommended rules
-    'plugin:@typescript-eslint/recommended-requiring-type-checking', // Additional type-checking rules
-    'plugin:import/typescript', // ESLint Typescript Import plugin
-    'plugin:security/recommended' // Security rules
+    // Airbnb style guide rules
+    'airbnb-typescript/base',
+    // ESLint Typescript plugin recommended rules
+    'plugin:@typescript-eslint/recommended',
+    // Additional type-checking rules
+    'plugin:@typescript-eslint/recommended-requiring-type-checking',
+    // ESLint Typescript Import plugin
+    'plugin:import/typescript',
+    // Security rules
+    'plugin:security/recommended',
+    // Jest rules
+    'plugin:jest/recommended'
+  ],
+  overrides: [
+    // @see https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/unbound-method.md
+    {
+      // Only turn the original rule off for test files.
+      'files': ['tests/**', 'test/**'],
+      'plugins': ['jest'],
+      'rules': {
+        '@typescript-eslint/unbound-method': 'off',
+        'jest/unbound-method': 'error'
+      }
+    }
   ],
   rules: {
-    '@typescript-eslint/interface-name-prefix': 'off', // Interfaces don't have to start with a I
-    '@typescript-eslint/no-use-before-define': 'off', // Allow defining functions (incl. arrow expressions) after use as per 'Stepdown Rule' best practice
+    // Interfaces don't have to start with a I
+    '@typescript-eslint/interface-name-prefix': 'off',
+    // Allow defining functions (incl. arrow expressions) after use as per 'Stepdown Rule' best practice
+    '@typescript-eslint/no-use-before-define': 'off',
+    // Allow referencing unbound methods as long as they are static
     '@typescript-eslint/unbound-method': [
-      'error', 
+      'error',
       { 'ignoreStatic': true }
-    ], // Allow referencing unbound methods as long as they are static
-    'class-methods-use-this': 'off', // Stops us from having to declare class methods which don't use this as static.
-    'eol-last': 2, // Enforces that files end with a newline 
-    'import/no-unresolved': [ // Allows you to use imports which can't be resolved, enabled for everything not in the ignore list.
-      2,
-      { 'ignore': ['@azure/functions'] } 
     ],
-    'import/prefer-default-export': 'off', // Allow named exports where there is only one module export
-    'max-len': 'off', // Disable default max line length of 100
-    'no-console': 'off', // Allow console logging for dev/test purposes
-    'no-plusplus': 'off', // Allow use of ++/-- operators given issues are extremely edge case
+    // Stops us from having to declare class methods which don't use this as static.
+    'class-methods-use-this': 'off',
+    // Enforces that files end with a newlines
+    'eol-last': 2,
+    // Allows you to use imports which can't be resolved, enabled for everything not in the ignore list.
+    'import/no-unresolved': [
+      2,
+      { 'ignore': ['@azure/functions'] }
+    ],
+    // Allow named exports where there is only one module export
+    'import/prefer-default-export': 'off',
+    // Disable default max line length of 100
+    'max-len': 'off',
+    // Allow console logging for dev/test purposes
+    'no-console': 'off',
+    // Allow use of ++/-- operators given issues are extremely edge case
+    'no-plusplus': 'off',
+    // Allow reassigning parameter properties but not whole parameters
     'no-param-reassign': [
-      'error', 
+      'error',
       { 'props': false }
-    ] // Allow reassigning parameter properties but not whole parameters
+    ],
+    '@typescript-eslint/unbound-method': 'error',
   },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/eslint-config-ts",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/eslint-config-ts",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "MIT",
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": ">=4.33.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,16 +9,16 @@
       "version": "2.3.0",
       "license": "MIT",
       "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "^4.33.0",
-        "@typescript-eslint/typescript-estree": "^4.33.0",
+        "@typescript-eslint/eslint-plugin": ">=4.33.0",
+        "@typescript-eslint/typescript-estree": ">=4.33.0",
         "eslint": ">=7.32.0",
-        "eslint-config-airbnb-typescript": "^12.3.1",
-        "eslint-plugin-import": "^2.24.2",
-        "eslint-plugin-jsx-a11y": "^6.4.1",
-        "eslint-plugin-react": "^7.26.1",
-        "eslint-plugin-react-hooks": "^4.2.0",
-        "eslint-plugin-security": "^1.4.0",
-        "typescript": ">=4.4.0"
+        "eslint-config-airbnb-typescript": ">=12.3.1",
+        "eslint-plugin-import": ">=2.24.2",
+        "eslint-plugin-jest": ">=25.2.4",
+        "eslint-plugin-jsx-a11y": ">=6.4.1",
+        "eslint-plugin-react": ">=7.26.1",
+        "eslint-plugin-react-hooks": ">=4.2.0",
+        "eslint-plugin-security": ">=1.4.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1011,6 +1011,137 @@
       "version": "2.0.0",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "peer": true
+    },
+    "node_modules/eslint-plugin-jest": {
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.2.4.tgz",
+      "integrity": "sha512-HRyinpgmEdkVr7pNPaYPHCoGqEzpgk79X8pg/xCeoAdurbyQjntJQ4pTzHl7BiVEBlam/F1Qsn+Dk0HtJO7Aaw==",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/eslint-plugin": "^4.0.0 || ^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/eslint-plugin": {
+          "optional": true
+        },
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/experimental-utils": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.1.tgz",
+      "integrity": "sha512-RgFn5asjZ5daUhbK5Sp0peq0SSMytqcrkNfU4pnDma2D8P3ElZ6JbYjY8IMSFfZAJ0f3x3tnO3vXHweYg0g59w==",
+      "peer": true,
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.3.1",
+        "@typescript-eslint/types": "5.3.1",
+        "@typescript-eslint/typescript-estree": "5.3.1",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "*"
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.1.tgz",
+      "integrity": "sha512-XksFVBgAq0Y9H40BDbuPOTUIp7dn4u8oOuhcgGq7EoDP50eqcafkMVGrypyVGvDYHzjhdUCUwuwVUK4JhkMAMg==",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.3.1",
+        "@typescript-eslint/visitor-keys": "5.3.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/types": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.1.tgz",
+      "integrity": "sha512-bG7HeBLolxKHtdHG54Uac750eXuQQPpdJfCYuw4ZI3bZ7+GgKClMWM8jExBtp7NSP4m8PmLRM8+lhzkYnSmSxQ==",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.3.1.tgz",
+      "integrity": "sha512-PwFbh/PKDVo/Wct6N3w+E4rLZxUDgsoII/GrWM2A62ETOzJd4M6s0Mu7w4CWsZraTbaC5UQI+dLeyOIFF1PquQ==",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.3.1",
+        "@typescript-eslint/visitor-keys": "5.3.1",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.1.tgz",
+      "integrity": "sha512-3cHUzUuVTuNHx0Gjjt5pEHa87+lzyqOiHXy/Gz+SJOCW1mpw9xQHIIEwnKn+Thph1mgWyZ90nboOcSuZr/jTTQ==",
+      "peer": true,
+      "dependencies": {
+        "@typescript-eslint/types": "5.3.1",
+        "eslint-visitor-keys": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-plugin-jest/node_modules/eslint-visitor-keys": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+      "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
+      "peer": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
     },
     "node_modules/eslint-plugin-jsx-a11y": {
       "version": "6.4.1",
@@ -3688,6 +3819,78 @@
         "ms": {
           "version": "2.0.0",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "peer": true
+        }
+      }
+    },
+    "eslint-plugin-jest": {
+      "version": "25.2.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-25.2.4.tgz",
+      "integrity": "sha512-HRyinpgmEdkVr7pNPaYPHCoGqEzpgk79X8pg/xCeoAdurbyQjntJQ4pTzHl7BiVEBlam/F1Qsn+Dk0HtJO7Aaw==",
+      "peer": true,
+      "requires": {
+        "@typescript-eslint/experimental-utils": "^5.0.0"
+      },
+      "dependencies": {
+        "@typescript-eslint/experimental-utils": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.1.tgz",
+          "integrity": "sha512-RgFn5asjZ5daUhbK5Sp0peq0SSMytqcrkNfU4pnDma2D8P3ElZ6JbYjY8IMSFfZAJ0f3x3tnO3vXHweYg0g59w==",
+          "peer": true,
+          "requires": {
+            "@types/json-schema": "^7.0.9",
+            "@typescript-eslint/scope-manager": "5.3.1",
+            "@typescript-eslint/types": "5.3.1",
+            "@typescript-eslint/typescript-estree": "5.3.1",
+            "eslint-scope": "^5.1.1",
+            "eslint-utils": "^3.0.0"
+          }
+        },
+        "@typescript-eslint/scope-manager": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.1.tgz",
+          "integrity": "sha512-XksFVBgAq0Y9H40BDbuPOTUIp7dn4u8oOuhcgGq7EoDP50eqcafkMVGrypyVGvDYHzjhdUCUwuwVUK4JhkMAMg==",
+          "peer": true,
+          "requires": {
+            "@typescript-eslint/types": "5.3.1",
+            "@typescript-eslint/visitor-keys": "5.3.1"
+          }
+        },
+        "@typescript-eslint/types": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.1.tgz",
+          "integrity": "sha512-bG7HeBLolxKHtdHG54Uac750eXuQQPpdJfCYuw4ZI3bZ7+GgKClMWM8jExBtp7NSP4m8PmLRM8+lhzkYnSmSxQ==",
+          "peer": true
+        },
+        "@typescript-eslint/typescript-estree": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.3.1.tgz",
+          "integrity": "sha512-PwFbh/PKDVo/Wct6N3w+E4rLZxUDgsoII/GrWM2A62ETOzJd4M6s0Mu7w4CWsZraTbaC5UQI+dLeyOIFF1PquQ==",
+          "peer": true,
+          "requires": {
+            "@typescript-eslint/types": "5.3.1",
+            "@typescript-eslint/visitor-keys": "5.3.1",
+            "debug": "^4.3.2",
+            "globby": "^11.0.4",
+            "is-glob": "^4.0.3",
+            "semver": "^7.3.5",
+            "tsutils": "^3.21.0"
+          }
+        },
+        "@typescript-eslint/visitor-keys": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.1.tgz",
+          "integrity": "sha512-3cHUzUuVTuNHx0Gjjt5pEHa87+lzyqOiHXy/Gz+SJOCW1mpw9xQHIIEwnKn+Thph1mgWyZ90nboOcSuZr/jTTQ==",
+          "peer": true,
+          "requires": {
+            "@typescript-eslint/types": "5.3.1",
+            "eslint-visitor-keys": "^3.0.0"
+          }
+        },
+        "eslint-visitor-keys": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
+          "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
           "peer": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/eslint-config-ts",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Shareable ESLint config for Node/Typescript projects",
   "main": "index.js",
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,16 +4,16 @@
   "description": "Shareable ESLint config for Node/Typescript projects",
   "main": "index.js",
   "peerDependencies": {
+    "@typescript-eslint/eslint-plugin": ">=4.33.0",
+    "@typescript-eslint/typescript-estree": ">=4.33.0",
     "eslint": ">=7.32.0",
-    "@typescript-eslint/eslint-plugin": "^4.33.0",
-    "@typescript-eslint/typescript-estree": "^4.33.0",
-    "eslint-config-airbnb-typescript": "^12.3.1",
-    "eslint-plugin-import": "^2.24.2",
-    "eslint-plugin-jsx-a11y": "^6.4.1",
-    "eslint-plugin-react": "^7.26.1",
-    "eslint-plugin-react-hooks": "^4.2.0",
-    "eslint-plugin-security": "^1.4.0",
-    "typescript": ">=4.4.0"
+    "eslint-config-airbnb-typescript": ">=12.3.1",
+    "eslint-plugin-import": ">=2.24.2",
+    "eslint-plugin-jest": ">=25.2.4",
+    "eslint-plugin-jsx-a11y": ">=6.4.1",
+    "eslint-plugin-react": ">=7.26.1",
+    "eslint-plugin-react-hooks": ">=4.2.0",
+    "eslint-plugin-security": ">=1.4.0"
   },
   "repository": "github:dvsa/eslint-config-ts",
   "keywords": [


### PR DESCRIPTION
Apologies, bundled a few changes in this - happy to split if any need more discussion.

**Changes:**
- Add `eslint-plugin-jest` - replace `@typescript-eslint/unbound-method` with `jest/unbound-method` in tests ([why](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/unbound-method.md))
- Add more flexible version constraints for plugins. `eslint` version 8 is a valid version per the constraints but the plugins don't allow the upgrade.
- Move the comments to the top of the rules instead of the side for readability.