### PR TITLE
Add `airbnb-base` to ruleset

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,8 @@ module.exports = {
     project: './tsconfig.json',
   },
   env: {
-    jest: 'true',
-    node: 'true'
+    jest: true,
+    node: true
   },
   plugins: [
     '@typescript-eslint',
@@ -17,6 +17,7 @@ module.exports = {
   ],
   extends: [
     // Airbnb style guide rules
+    'airbnb-base',
     'airbnb-typescript/base',
     // ESLint Typescript plugin recommended rules
     'plugin:@typescript-eslint/recommended',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/eslint-config-ts",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/eslint-config-ts",
-      "version": "2.5.0",
+      "version": "3.0.0",
       "license": "MIT",
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": ">=4.33.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@typescript-eslint/eslint-plugin": ">=4.33.0",
         "@typescript-eslint/typescript-estree": ">=4.33.0",
         "eslint": ">=7.32.0",
+        "eslint-config-airbnb-base": ">=14.2.0",
         "eslint-config-airbnb-typescript": ">=12.3.1",
         "eslint-plugin-import": ">=2.24.2",
         "eslint-plugin-jest": ">=25.2.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@dvsa/eslint-config-ts",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@dvsa/eslint-config-ts",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "MIT",
       "peerDependencies": {
         "@typescript-eslint/eslint-plugin": ">=4.33.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@typescript-eslint/eslint-plugin": ">=4.33.0",
     "@typescript-eslint/typescript-estree": ">=4.33.0",
     "eslint": ">=7.32.0",
+    "eslint-config-airbnb-base": ">=14.2.0",
     "eslint-config-airbnb-typescript": ">=12.3.1",
     "eslint-plugin-import": ">=2.24.2",
     "eslint-plugin-jest": ">=25.2.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/eslint-config-ts",
-  "version": "2.5.0",
+  "version": "3.0.0",
   "description": "Shareable ESLint config for Node/Typescript projects",
   "main": "index.js",
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/eslint-config-ts",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Shareable ESLint config for Node/Typescript projects",
   "main": "index.js",
   "peerDependencies": {


### PR DESCRIPTION
At the moment, the rules don't target much of the JavaScript syntax as the `airbnb-base` isn't extended. 

Repo: https://github.com/airbnb/javascript

**This MR:**
- Adds `airbnb-base` to the `extends` section.

